### PR TITLE
Fixes for Mac and Linux

### DIFF
--- a/translation_patch.c
+++ b/translation_patch.c
@@ -27,7 +27,7 @@
 
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
-#ifdef __unix__         
+#if defined(__unix__) || defined(__APPLE__)         
 
 #define OS_SEP_CH '/'
 #define OS_SEP "/"

--- a/translations/languages.rb
+++ b/translations/languages.rb
@@ -96,7 +96,7 @@ if ($DEBUG || $TEST) and (ENV["LOADED_RAKUEN"].nil?)
   # Set the title of the console debug window'
   Win32API.new('kernel32','SetConsoleTitleA','P','S').call("#{title} :  Debug Console")
   # Draw the header, displaying current time.
-  puts ('=' * 75, Time.now, '=' * 75, "\n")
+  puts('=' * 75, Time.now, '=' * 75, "\n")
   # ...
 
   class Game_Map


### PR DESCRIPTION
These changes let the translation_patch to compile on Mac, also one small syntax fix for languages.rb makes it work on mkxp based Mac and Linux ports of the game.